### PR TITLE
Hiscores scale after hitting 999,99s

### DIFF
--- a/Dudeman's Adventures/Assets/Scripts/MenuScripts/HighScores/HighScoreScript.cs
+++ b/Dudeman's Adventures/Assets/Scripts/MenuScripts/HighScores/HighScoreScript.cs
@@ -15,7 +15,12 @@ public class HighScoreScript : MonoBehaviour
         {
             if(PlayerPrefs.HasKey("Level0" + (i + 1) + "HighScore") == true)
             {
-                highScoreFields[i].text = PlayerPrefs.GetFloat("Level0" + (i + 1) + "HighScore").ToString("0.00") + "s";
+                float highScore = PlayerPrefs.GetFloat("Level0" + (i + 1) + "HighScore");
+                if(highScore > 999.99)
+                {
+                    highScoreFields[i].fontSize = 20;
+                }
+                highScoreFields[i].text = highScore.ToString("0.00") + "s";
             }
         }
     }


### PR DESCRIPTION
**Addition:**

- Added scaling into the Hiscores: after 999,99s the fontsize is made smaller so that all times until 9999,99s can be shown on screen
(I suppose people won't be spending over 2.5 hours on a single level :D)

**Testing:**

- Reset scores, start Level01, put 999 into "Score Time" (Canvas -> Score Timer -> Score Manager (Script)), wait a bit, finish the level and check that the whole number is shown on Hiscores

_I'm feeling thank you_